### PR TITLE
Added torchaudio rocm 7.1

### DIFF
--- a/script_module_ROCm_720_Ubuntu_22.04-24.04_pytorch_server.sh
+++ b/script_module_ROCm_720_Ubuntu_22.04-24.04_pytorch_server.sh
@@ -156,7 +156,7 @@ install_jellyfish() {
     python3 -m pip install --upgrade pip wheel --quiet --no-input
     python3 -m pip install joblib --quiet --no-input
     python3 -m pip install setuptools_scm --quiet --no-input
-    python3 -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1 --no-input
+    python3 -m pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1 --no-input
     python3 -m pip install transformers --quiet --no-input
     python3 -m pip install accelerate --quiet --no-input
     python3 -m pip install -U diffusers --quiet --no-input
@@ -253,7 +253,7 @@ install_noble() {
     pip3 install --upgrade pip wheel --break-system-packages
     pip3 install joblib --break-system-packages
     pip3 install setuptools_scm --break-system-packages
-    pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.1 --no-input --break-system-packages
+    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1 --no-input --break-system-packages
     pip3 install transformers --break-system-packages
     pip3 install accelerate --break-system-packages
     pip3 install -U diffusers --break-system-packages


### PR DESCRIPTION
I am not sure if it was intended, but torchaudio is not defined as packages to be installed alongside torch and torchvision. It is specifically defined to be uninstalled when running the bash script:

```bash
# Within install_jellyfish() and install_noble()
    # Use pip with --break-system-packages to avoid "externally-managed-environment" error
    if python3 -m pip list | grep torch; then
        python3 -m pip uninstall -y torch torchvision torchaudio pytorch-triton-rocm
        printf "\nPyTorch packages uninstalled successfully.\n"
    else
        printf "\nNo PyTorch packages found.\n"
    fi
```

For my projects I need torchaudio and added it therefore to the install script. If there is a reason why it was not included, please let me know. 

P.S. Thank you for contributing this install script, it's a time saver!!

